### PR TITLE
Fix nfi32_rsi_14 default

### DIFF
--- a/strategies/ClucHAnix5m/ClucHAnix5m.py
+++ b/strategies/ClucHAnix5m/ClucHAnix5m.py
@@ -196,7 +196,7 @@ class ClucHAnix5m(IStrategy):
 
     # nfi32
     nfi32_rsi_4 = IntParameter(1, 100, default=buy_params['nfi32_rsi_4'], space='buy', optimize=True)
-    nfi32_rsi_14 = IntParameter(1, 100, default=buy_params['nfi32_rsi_4'], space='buy', optimize=True)
+    nfi32_rsi_14 = IntParameter(1, 100, default=buy_params['nfi32_rsi_14'], space='buy', optimize=True)
     nfi32_sma_factor = DecimalParameter(0.7, 1.2, default=buy_params['nfi32_sma_factor'], decimals=5, space='buy', optimize=True)
     nfi32_cti_limit = DecimalParameter(-1.2, 0, default=buy_params['nfi32_cti_limit'], decimals=5, space='buy', optimize=True)
 


### PR DESCRIPTION
## Summary
- reference `buy_params['nfi32_rsi_14']` when initializing `nfi32_rsi_14`

## Testing
- `python -m py_compile strategies/ClucHAnix5m/ClucHAnix5m.py`

------
https://chatgpt.com/codex/tasks/task_e_687f698163988333a630a7f39a2594e2