### PR TITLE
Add docstrings to ClucHAnix classes

### DIFF
--- a/strategies/ClucHAnix5m/ClucHAnix5m.py
+++ b/strategies/ClucHAnix5m/ClucHAnix5m.py
@@ -32,6 +32,14 @@ def ha_typical_price(bars):
     return Series(index=bars.index, data=res)
 
 class ClucHAnix5m(IStrategy):
+    """5 minute variant of the ClucHAnix strategy.
+
+    Combines Heikin‑Ashi candles, Bollinger band checks and
+    momentum indicators such as EWO/RSI to time entries.  Includes
+    custom stoploss logic and optional trailing buy management to
+    adapt to rapid market moves.
+    """
+
     INTERFACE_VERSION = 3
 
     # Buy hyperspace params:
@@ -492,6 +500,13 @@ def EWO(dataframe, ema_length=5, ema2_length=35):
     return emadif
 
 class ClucHAnix_BB_RPB_MOD2_ROI_DYNAMIC_TB(ClucHAnix5m):
+    """Extension with dynamic trailing buy.
+
+    Implements the same indicators as ``ClucHAnix5m`` but
+    manages entries with an adaptive trailing buy system that
+    adjusts offsets according to recent volatility and cancels
+    or forces orders based on time and price conditions.
+    """
 
     process_only_new_candles = True
 

--- a/strategies/ClucHAnix_BB_RPB_MOD2_ROI/ClucHAnix_BB_RPB_MOD2_ROI.py
+++ b/strategies/ClucHAnix_BB_RPB_MOD2_ROI/ClucHAnix_BB_RPB_MOD2_ROI.py
@@ -493,6 +493,14 @@ def EWO(dataframe, ema_length=5, ema2_length=35):
     return emadif
 
 class ClucHAnix_BB_RPB_MOD2_ROI_DYNAMIC_TB(ClucHAnix_BB_RPB_MOD2_ROI):
+    """ClucHAnix with dynamic trailing buy logic.
+
+    Inherits the Bollinger band and ROI modifications from
+    ``ClucHAnix_BB_RPB_MOD2_ROI`` and adds a volatility‑aware
+    trailing buy mechanism.  This mechanism adapts the buy
+    offset based on recent price swings and can trigger or
+    cancel buys according to time and profit thresholds.
+    """
 
     process_only_new_candles = True
 


### PR DESCRIPTION
## Summary
- document intent of `ClucHAnix5m`
- document intent of `ClucHAnix_BB_RPB_MOD2_ROI_DYNAMIC_TB`
- document intent of dynamic trailing-buy subclass in `ClucHAnix5m`

## Testing
- `flake8 strategies/ClucHAnix5m/ClucHAnix5m.py strategies/ClucHAnix_BB_RPB_MOD2_ROI/ClucHAnix_BB_RPB_MOD2_ROI.py`

------
https://chatgpt.com/codex/tasks/task_e_687f698c62148333836313203e80ae59